### PR TITLE
Orchestrator service config validation

### DIFF
--- a/src/clients/chunker.rs
+++ b/src/clients/chunker.rs
@@ -37,7 +37,7 @@ use crate::{
 
 const MODEL_ID_HEADER_NAME: &str = "mm-model-id";
 /// Default chunker that returns span for entire text
-const DEFAULT_MODEL_ID: &str = "whole_doc_chunker";
+pub const DEFAULT_MODEL_ID: &str = "whole_doc_chunker";
 
 type StreamingTokenizationResult =
     Result<Response<Streaming<ChunkerTokenizationStreamResult>>, Status>;

--- a/src/clients/generation.rs
+++ b/src/clients/generation.rs
@@ -67,10 +67,6 @@ impl GenerationClient {
         Self(None)
     }
 
-    pub fn is_configured(&self) -> bool {
-        self.0.is_some()
-    }
-
     pub async fn tokenize(
         &self,
         model_id: String,

--- a/src/clients/generation.rs
+++ b/src/clients/generation.rs
@@ -38,7 +38,7 @@ use crate::{
 
 #[cfg_attr(test, faux::create, derive(Default))]
 #[derive(Clone)]
-pub struct GenerationClient(GenerationClientInner);
+pub struct GenerationClient(Option<GenerationClientInner>);
 
 #[derive(Clone)]
 enum GenerationClientInner {
@@ -56,11 +56,19 @@ impl Default for GenerationClientInner {
 #[cfg_attr(test, faux::methods)]
 impl GenerationClient {
     pub fn tgis(client: TgisClient) -> Self {
-        Self(GenerationClientInner::Tgis(client))
+        Self(Some(GenerationClientInner::Tgis(client)))
     }
 
     pub fn nlp(client: NlpClient) -> Self {
-        Self(GenerationClientInner::Nlp(client))
+        Self(Some(GenerationClientInner::Nlp(client)))
+    }
+
+    pub fn not_configured() -> Self {
+        Self(None)
+    }
+
+    pub fn is_configured(&self) -> bool {
+        self.0.is_some()
     }
 
     pub async fn tokenize(
@@ -69,7 +77,7 @@ impl GenerationClient {
         text: String,
     ) -> Result<(u32, Vec<String>), Error> {
         match &self.0 {
-            GenerationClientInner::Tgis(client) => {
+            Some(GenerationClientInner::Tgis(client)) => {
                 let request = BatchedTokenizeRequest {
                     model_id: model_id.clone(),
                     requests: vec![TokenizeRequest { text }],
@@ -83,7 +91,7 @@ impl GenerationClient {
                 let response = response.responses.swap_remove(0);
                 Ok((response.token_count, response.tokens))
             }
-            GenerationClientInner::Nlp(client) => {
+            Some(GenerationClientInner::Nlp(client)) => {
                 let request = TokenizationTaskRequest { text };
                 debug!(%model_id, provider = "nlp", ?request, "sending tokenize request");
                 let response = client.tokenization_task_predict(&model_id, request).await?;
@@ -95,6 +103,7 @@ impl GenerationClient {
                     .collect::<Vec<_>>();
                 Ok((response.token_count as u32, tokens))
             }
+            None => Err(Error::ModelNotFound { model_id }),
         }
     }
 
@@ -105,7 +114,7 @@ impl GenerationClient {
         params: Option<GuardrailsTextGenerationParameters>,
     ) -> Result<ClassifiedGeneratedTextResult, Error> {
         match &self.0 {
-            GenerationClientInner::Tgis(client) => {
+            Some(GenerationClientInner::Tgis(client)) => {
                 let params = params.map(Into::into);
                 let request = BatchedGenerationRequest {
                     model_id: model_id.clone(),
@@ -118,7 +127,7 @@ impl GenerationClient {
                 debug!(%model_id, provider = "tgis", ?response, "received generate response");
                 Ok(response.into())
             }
-            GenerationClientInner::Nlp(client) => {
+            Some(GenerationClientInner::Nlp(client)) => {
                 let request = if let Some(params) = params {
                     TextGenerationTaskRequest {
                         text,
@@ -157,6 +166,7 @@ impl GenerationClient {
                 debug!(%model_id, provider = "nlp", ?response, "received generate response");
                 Ok(response.into())
             }
+            None => Err(Error::ModelNotFound { model_id }),
         }
     }
 
@@ -167,7 +177,7 @@ impl GenerationClient {
         params: Option<GuardrailsTextGenerationParameters>,
     ) -> Result<BoxStream<Result<ClassifiedGeneratedTextStreamResult, Error>>, Error> {
         match &self.0 {
-            GenerationClientInner::Tgis(client) => {
+            Some(GenerationClientInner::Tgis(client)) => {
                 let params = params.map(Into::into);
                 let request = SingleGenerationRequest {
                     model_id: model_id.clone(),
@@ -183,7 +193,7 @@ impl GenerationClient {
                     .boxed();
                 Ok(response_stream)
             }
-            GenerationClientInner::Nlp(client) => {
+            Some(GenerationClientInner::Nlp(client)) => {
                 let request = if let Some(params) = params {
                     ServerStreamingTextGenerationTaskRequest {
                         text,
@@ -223,6 +233,7 @@ impl GenerationClient {
                     .boxed();
                 Ok(response_stream)
             }
+            None => Err(Error::ModelNotFound { model_id }),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use serde::Deserialize;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::{clients::chunker::DEFAULT_MODEL_ID, server};
 
@@ -180,6 +180,13 @@ impl OrchestratorConfig {
         let config_yaml = tokio::fs::read_to_string(path).await?;
         let mut config: OrchestratorConfig = serde_yml::from_str(&config_yaml)?;
         debug!(?config, "loaded orchestrator config");
+
+        if config.generation.is_none() {
+            warn!("no generation config provided");
+        }
+        if config.chunkers.is_none() {
+            warn!("no chunker configs provided");
+        }
 
         config.apply_named_tls_configs()?;
         config.validate()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,20 +175,16 @@ pub struct OrchestratorConfig {
 }
 
 impl OrchestratorConfig {
-    /// Load overall orchestrator server configuration
+    /// Loads config
     pub async fn load(path: impl AsRef<Path>) -> Result<Self, Error> {
-        let mut config = Self::from_file(path).await?;
+        let config_yaml = tokio::fs::read_to_string(path).await?;
+        let mut config: OrchestratorConfig = serde_yml::from_str(&config_yaml)?;
         debug!(?config, "loaded orchestrator config");
 
         config.apply_named_tls_configs()?;
         config.validate()?;
-        Ok(config)
-    }
 
-    async fn from_file(path: impl AsRef<Path>) -> Result<Self, Error> {
-        let path = path.as_ref();
-        let s = tokio::fs::read_to_string(path).await.map_err(Error::from)?;
-        serde_yml::from_str(&s).map_err(Error::from)
+        Ok(config)
     }
 
     /// Applies named TLS configs to services.

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ use std::{
 use serde::Deserialize;
 use tracing::{debug, error, warn};
 
-use crate::{clients::chunker::DEFAULT_MODEL_ID, server};
+use crate::clients::chunker::DEFAULT_MODEL_ID;
 
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum Error {
@@ -41,20 +41,6 @@ pub enum Error {
     NoDetectorsConfigured,
     #[error("config for detector `{detector}` has an unknown chunker_id `{chunker}`")]
     DetectorChunkerNotFound { detector: String, chunker: String },
-}
-
-impl From<Error> for server::Error {
-    fn from(error: Error) -> Self {
-        match error {
-            Error::FailedToReadConfigFile { .. }
-            | Error::FailedToSerializeConfigFile { .. }
-            | Error::TlsConfigNotFound { .. }
-            | Error::NoDetectorsConfigured
-            | Error::DetectorChunkerNotFound { .. } => {
-                server::Error::ConfigurationFailed(error.to_string())
-            }
-        }
-    }
 }
 
 impl From<serde_yml::Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,6 @@
 mod clients;
 pub mod config;
 mod models;
-mod orchestrator;
+pub mod orchestrator;
 mod pb;
 pub mod server;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![allow(clippy::iter_kv_map, clippy::enum_variant_names)]
 
 mod clients;
-mod config;
+pub mod config;
 mod models;
 mod orchestrator;
 mod pb;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use std::{
 use clap::Parser;
 use fms_guardrails_orchestr8::server;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use fms_guardrails_orchestr8::config::OrchestratorConfig;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -75,15 +76,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()
         .unwrap()
         .block_on(async {
+            let config = OrchestratorConfig::load(args.config_path).await?;
             server::run(
                 http_addr,
                 health_http_addr,
                 args.tls_cert_path,
                 args.tls_key_path,
                 args.tls_client_ca_cert_path,
-                args.config_path,
+                config,
             )
-            .await?;
+                .await?;
             Ok(())
         })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,8 @@ use std::{
 };
 
 use clap::Parser;
-use fms_guardrails_orchestr8::server;
+use fms_guardrails_orchestr8::{config::OrchestratorConfig, orchestrator::Orchestrator, server};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use fms_guardrails_orchestr8::config::OrchestratorConfig;
-use fms_guardrails_orchestr8::orchestrator::Orchestrator;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -45,7 +43,7 @@ struct Args {
     tls_client_ca_cert_path: Option<PathBuf>,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), anyhow::Error> {
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("Failed to install rustls crypto provider");
@@ -89,7 +87,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 args.tls_client_ca_cert_path,
                 orchestrator,
             )
-                .await?;
+            .await?;
             Ok(())
         })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use clap::Parser;
 use fms_guardrails_orchestr8::server;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use fms_guardrails_orchestr8::config::OrchestratorConfig;
+use fms_guardrails_orchestr8::orchestrator::Orchestrator;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -77,13 +78,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap()
         .block_on(async {
             let config = OrchestratorConfig::load(args.config_path).await?;
+            // TODO: Error handling during orchestrator creation
+            let orchestrator = Orchestrator::new(config).await?;
+
             server::run(
                 http_addr,
                 health_http_addr,
                 args.tls_cert_path,
                 args.tls_key_path,
                 args.tls_client_ca_cert_path,
-                config,
+                orchestrator,
             )
                 .await?;
             Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -71,7 +71,7 @@ pub async fn run(
     tls_cert_path: Option<PathBuf>,
     tls_key_path: Option<PathBuf>,
     tls_client_ca_cert_path: Option<PathBuf>,
-    config_path: PathBuf,
+    config: OrchestratorConfig,
 ) -> Result<(), Error> {
     // Overall, the server setup and run does a couple of steps:
     // (1) Sets up a HTTP server (without TLS) for the health endpoint
@@ -85,15 +85,6 @@ pub async fn run(
     // with rustls, the hyper and tower crates [what axum is built on] had to
     // be used directly
 
-    let config = OrchestratorConfig::load(config_path)
-        .await
-        .map_err(Error::from)
-        .map_err(|error| match error {
-            Error::ConfigurationFailed(_) => error,
-            _ => {
-                panic!("Unexpected error during service configuration: {error}");
-            }
-        })?;
     let orchestrator = Orchestrator::new(config).await?;
     let shared_state = Arc::new(ServerState { orchestrator });
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,7 +43,6 @@ use uuid::Uuid;
 use webpki::types::{CertificateDer, PrivateKeyDer};
 
 use crate::{
-    config::OrchestratorConfig,
     models::{self},
     orchestrator::{
         self, ClassificationWithGenTask, ContextDocsDetectionTask, DetectionOnGenerationTask,
@@ -71,7 +70,7 @@ pub async fn run(
     tls_cert_path: Option<PathBuf>,
     tls_key_path: Option<PathBuf>,
     tls_client_ca_cert_path: Option<PathBuf>,
-    config: OrchestratorConfig,
+    orchestrator: Orchestrator,
 ) -> Result<(), Error> {
     // Overall, the server setup and run does a couple of steps:
     // (1) Sets up a HTTP server (without TLS) for the health endpoint
@@ -85,7 +84,6 @@ pub async fn run(
     // with rustls, the hyper and tower crates [what axum is built on] had to
     // be used directly
 
-    let orchestrator = Orchestrator::new(config).await?;
     let shared_state = Arc::new(ServerState { orchestrator });
 
     // (1) Separate HTTP health server without TLS for probes
@@ -468,8 +466,6 @@ pub enum Error {
     NotFound(String),
     #[error("{0}")]
     ServiceUnavailable(String),
-    #[error("{0}")]
-    ConfigurationFailed(String),
     #[error("unexpected error occured while processing request")]
     Unexpected,
     #[error(transparent)]
@@ -505,9 +501,6 @@ impl Error {
             NotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
             ServiceUnavailable(_) => (StatusCode::SERVICE_UNAVAILABLE, self.to_string()),
             Unexpected => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
-            ConfigurationFailed(_) => {
-                panic!("service configuration error should not be returned to client")
-            }
             JsonExtractorRejection(json_rejection) => match json_rejection {
                 JsonRejection::JsonDataError(e) => {
                     // Get lower-level serde error message
@@ -532,9 +525,6 @@ impl IntoResponse for Error {
             NotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
             ServiceUnavailable(_) => (StatusCode::SERVICE_UNAVAILABLE, self.to_string()),
             Unexpected => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
-            ConfigurationFailed(_) => {
-                panic!("service configuration error should not be returned to client")
-            }
             JsonExtractorRejection(json_rejection) => match json_rejection {
                 JsonRejection::JsonDataError(e) => {
                     // Get lower-level serde error message


### PR DESCRIPTION
### Description

For Issue https://github.com/foundation-model-stack/fms-guardrails-orchestrator/issues/23

#### Changes
- introduced config error type variants
- made `tls`, `chunkers` and `generation` config sections optional
    - `tls` may also be provided inlined to a service config
    - `chunkers` can be omitted, in which case the default `"whole_doc_chunker"` chunker will be subsidized
    - `generation` as a whole may be omitted from configuration
- support for and error handling of optional generation client configuration
- implemented validation logic and error handling to tls config mapping
- added more config validation tests